### PR TITLE
Freshbook-node: index: fixing how easyxml is initialized

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function Freshbooks(account, token, agent, showAttributes) {
     this.token = token;
     this.agent = agent;
     this.parser = new xml2js.Parser({explicitArray: false, ignoreAttrs: showAttributes !== undefined ? (showAttributes ? false : true) : true, async: true});
-    easyxml.configure({rootElement: 'request', manifest: true});
+    this.easyxml_parser = new easyxml({rootElement: 'request', manifest: true});
 }
 
 Freshbooks.prototype.call = function(method, json, callback) {
@@ -18,7 +18,7 @@ Freshbooks.prototype.call = function(method, json, callback) {
         xml = '<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<request>\n</request>\n'
     }
     else {
-        xml = easyxml.render(json);
+        xml = self.easyxml_parser.render(json);
     }
     xml = xml.replace('<request>', '<request method="' + method + '">');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freshbooks-node",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "dependencies": {
     "request": "*",
 	"easyxml": "*",


### PR DESCRIPTION
The easyxml module changed how the parser is initialized. Had to update this module to reflect this. https://github.com/tlhunter/node-easyxml

 * The server is using an old version of the module, so robots run fine there. It's just for local machines.*